### PR TITLE
Add :root for global font and colour scheme in style.css

### DIFF
--- a/src/HTML/about.html
+++ b/src/HTML/about.html
@@ -12,7 +12,10 @@
   <link rel="manifest" href="../site.webmanifest">
   <meta name="theme-color" content="#fafafa">
   <meta name="description" content="Learn about Cubble." />
-
+  <!-- Google Fonts: Quicksand -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/src/HTML/apps.html
+++ b/src/HTML/apps.html
@@ -13,6 +13,10 @@
   <link rel="icon" href="../favicon.ico" sizes="any">
   <link rel="manifest" href="../site.webmanifest">
   <meta name="theme-color" content="#fafafa">
+  <!-- Google Fonts: Quicksand -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/src/HTML/banner.html
+++ b/src/HTML/banner.html
@@ -242,6 +242,10 @@
       }
     }
   </style>
+  <!-- Google Fonts: Quicksand -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/src/HTML/footer.html
+++ b/src/HTML/footer.html
@@ -1,5 +1,9 @@
 <head>
   <link rel="stylesheet" href="../css/footer.css">
+  <!-- Google Fonts: Quicksand -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <footer class="site-footer">

--- a/src/HTML/index.html
+++ b/src/HTML/index.html
@@ -17,6 +17,10 @@
   <link rel="icon" href="../favicon.ico" sizes="any">
   <link rel="manifest" href="../site.webmanifest">
   <meta name="theme-color" content="#fafafa">
+  <!-- Google Fonts: Quicksand -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/src/HTML/signUp.html
+++ b/src/HTML/signUp.html
@@ -7,6 +7,10 @@
     <title>Join our Mailing List</title>
     <link rel="stylesheet" href="../css/signUp.css">
     <script defer src="../js/banner.js"></script>
+    <!-- Google Fonts: Quicksand -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/src/HTML/team-map.html
+++ b/src/HTML/team-map.html
@@ -10,7 +10,10 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css" />
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster.js"></script>
-
+  <!-- Google Fonts: Quicksand -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/src/HTML/unsubscribe.html
+++ b/src/HTML/unsubscribe.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Join our Mailing List</title>
     <link rel="stylesheet" href="../css/unsubscribe.css">
+    <!-- Google Fonts: Quicksand -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300..700&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -138,7 +138,7 @@ html.is-mobile .stuff-box {
 
 #how-it-works {
   padding: 60px 20px;
-  background: linear-gradient(135deg, rgba(255, 48, 133, 0.25) 0%, rgba(91, 77, 242, 0.25) 50%, rgba(33, 150, 243, 0.25) 100%);
+  background: var(--primary);
   text-align: center;
 }
 
@@ -146,6 +146,8 @@ html.is-mobile .stuff-box {
   font-size: 2rem;
   margin-bottom: 40px;
   color: #222;
+  font-family: var(--font-family);
+  font-weight: var(--font-bold); 
 }
 
 .how-block {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -7,6 +7,27 @@
  * Kroc Camen, and the H5BP dev community and team.
  */
 
+:root {
+  /* Colors */
+  --primary-light: #5cef9e;
+  --primary: #04bfad;
+  --primary-dark: #025159;
+
+  --secondary-light: #35528c;
+  --secondary: #735a8c;
+  --secondary-dark: #252359;
+
+  --tertiary-light: #f25922;
+  --tertiary: #f20505;
+  --tertiary-dark: #73020c;
+
+  /* Fonts */
+  --font-family: "Quicksand", sans-serif;
+  --font-light: 300;
+  --font-regular: 400;
+  --font-bold: 700;
+}
+
   html, body, #root {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
Defined global CSS variables for font and colour scheme in style.css.  
This allows other developers to start using the variables in their components.  

Note: The existing styles have not yet been updated to use the new variables.  
Integration into the site’s colour scheme will follow in the future commit.
